### PR TITLE
fix CD typo doc comment

### DIFF
--- a/main_CBC.m
+++ b/main_CBC.m
@@ -11,7 +11,7 @@ addpath('src/');
 
 %% Load data
 
-load Force_data.mat;                     % CL,CL,CL_dot,t
+load Force_data.mat;                     % CL,CD,CL_dot,t
 M          = 0.3;                        % Mach number
 Re         = 23000;                      % Reynolds number
 width      = 0.2;                        % width in spanwise direction


### PR DESCRIPTION
in `main_CBC.m` the `CL` variable is mentioned twice and is missing `CD`. Also, this PR removes a new line at the end of the file. I'm sure where this comes from, I suspect its related to the MATLAB ide differences. The end of files appear the same for your commit and mine.